### PR TITLE
🐛 Omit value when it's a reference to self (class name)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@babel/plugin-proposal-decorators": "^7.4.0",
     "@babel/preset-env": "^7.4.2",
     "@babel/preset-typescript": "^7.3.3",
+    "@babel/template": "^7.4.0",
     "@favoloso/conventional-changelog-emoji": "^0.9.0",
     "@types/jest": "^24.0.11",
     "babel-test": "^0.1.6",

--- a/src/metadata/serializeType.ts
+++ b/src/metadata/serializeType.ts
@@ -17,6 +17,8 @@ function createVoidZero() {
  * @todo Rest parameters are not supported.
  */
 function getTypedNode(param: Parameter): t.Identifier | t.ClassProperty | null {
+  if (param == null) return null;
+
   if (param.type === 'ClassProperty') return param;
   if (param.type === 'Identifier') return param;
 
@@ -34,8 +36,8 @@ export function serializeType(
   param: Parameter
 ) {
   const node = getTypedNode(param);
-
   if (node == null) return createVoidZero();
+
   if (!node.typeAnnotation || node.typeAnnotation.type !== 'TSTypeAnnotation')
     return createVoidZero();
 
@@ -87,7 +89,7 @@ function serializeTypeReferenceNode(
  * expression or identifier is a reference to self (class name).
  * In this case, we just emit `Object` in order to avoid ReferenceError.
  */
-function isClassType(className: string, node: t.Expression): boolean {
+export function isClassType(className: string, node: t.Expression): boolean {
   switch (node.type) {
     case 'Identifier':
       return node.name === className;

--- a/src/metadata/serializeType.ts
+++ b/src/metadata/serializeType.ts
@@ -29,7 +29,10 @@ function getTypedNode(param: Parameter): t.Identifier | t.ClassProperty | null {
   return null;
 }
 
-export function serializeType(path: NodePath<any>, param: Parameter) {
+export function serializeType(
+  classPath: NodePath<t.ClassDeclaration>,
+  param: Parameter
+) {
   const node = getTypedNode(param);
 
   if (node == null) return createVoidZero();
@@ -37,10 +40,14 @@ export function serializeType(path: NodePath<any>, param: Parameter) {
     return createVoidZero();
 
   const annotation = node.typeAnnotation.typeAnnotation;
-  return serializeTypeNode(annotation);
+  const className = classPath.node.id ? classPath.node.id.name : '';
+  return serializeTypeNode(className, annotation);
 }
 
-function serializeTypeReferenceNode(node: t.TSTypeReference) {
+function serializeTypeReferenceNode(
+  className: string,
+  node: t.TSTypeReference
+) {
   /**
    * We need to save references to this type since it is going
    * to be used as a Value (and not just as a Type) here.
@@ -49,6 +56,14 @@ function serializeTypeReferenceNode(node: t.TSTypeReference) {
    * `path.scope.crawl()` which updates the bindings.
    */
   const reference = serializeReference(node.typeName);
+
+  /**
+   * We should omit references to self (class) since it will throw a
+   * ReferenceError at runtime due to babel transpile output.
+   */
+  if (isClassType(className, reference)) {
+    return t.identifier('Object');
+  }
 
   /**
    * We don't know if type is just a type (interface, etc.) or a concrete
@@ -67,10 +82,32 @@ function serializeTypeReferenceNode(node: t.TSTypeReference) {
   );
 }
 
+/**
+ * Checks if node (this should be the result of `serializeReference`) member
+ * expression or identifier is a reference to self (class name).
+ * In this case, we just emit `Object` in order to avoid ReferenceError.
+ */
+function isClassType(className: string, node: t.Expression): boolean {
+  switch (node.type) {
+    case 'Identifier':
+      return node.name === className;
+    case 'MemberExpression':
+      return isClassType(className, node.object);
+    default:
+      throw new Error(
+        `The property expression at ${
+          node.start
+        } is not valid as a Type to be used in Reflect.metadata`
+      );
+  }
+}
+
 function serializeReference(
   typeName: t.Identifier | t.TSQualifiedName
 ): t.Identifier | t.MemberExpression {
-  if (typeName.type === 'Identifier') return t.identifier(typeName.name);
+  if (typeName.type === 'Identifier') {
+    return t.identifier(typeName.name);
+  }
   return t.memberExpression(serializeReference(typeName.left), typeName.right);
 }
 
@@ -87,7 +124,7 @@ type SerializedType =
  * available here:
  *  https://github.com/Microsoft/TypeScript/blob/2932421370df720f0ccfea63aaf628e32e881429/src/compiler/transformers/ts.ts
  */
-function serializeTypeNode(node: t.TSType): SerializedType {
+function serializeTypeNode(className: string, node: t.TSType): SerializedType {
   if (node === undefined) {
     return t.identifier('Object');
   }
@@ -100,7 +137,7 @@ function serializeTypeNode(node: t.TSType): SerializedType {
       return createVoidZero();
 
     case 'TSParenthesizedType':
-      return serializeTypeNode(node.typeAnnotation);
+      return serializeTypeNode(className, node.typeAnnotation);
 
     case 'TSFunctionType':
     case 'TSConstructorType':
@@ -145,14 +182,14 @@ function serializeTypeNode(node: t.TSType): SerializedType {
       return t.identifier('Symbol');
 
     case 'TSTypeReference':
-      return serializeTypeReferenceNode(node);
+      return serializeTypeReferenceNode(className, node);
 
     case 'TSIntersectionType':
     case 'TSUnionType':
-      return serializeTypeList(node.types);
+      return serializeTypeList(className, node.types);
 
     case 'TSConditionalType':
-      return serializeTypeList([node.trueType, node.falseType]);
+      return serializeTypeList(className, [node.trueType, node.falseType]);
 
     case 'TSTypeQuery':
     case 'TSTypeOperator':
@@ -178,7 +215,10 @@ function serializeTypeNode(node: t.TSType): SerializedType {
  *
  *  https://github.com/Microsoft/TypeScript/blob/2932421370df720f0ccfea63aaf628e32e881429/src/compiler/transformers/ts.ts
  */
-function serializeTypeList(types: ReadonlyArray<t.TSType>): SerializedType {
+function serializeTypeList(
+  className: string,
+  types: ReadonlyArray<t.TSType>
+): SerializedType {
   let serializedUnion: SerializedType | undefined;
 
   for (let typeNode of types) {
@@ -194,7 +234,7 @@ function serializeTypeList(types: ReadonlyArray<t.TSType>): SerializedType {
     ) {
       continue; // Elide null and undefined from unions for metadata, just like what we did prior to the implementation of strict null checks
     }
-    const serializedIndividual = serializeTypeNode(typeNode);
+    const serializedIndividual = serializeTypeNode(className, typeNode);
 
     if (
       t.isIdentifier(serializedIndividual) &&

--- a/test/__node__/self-reference/code.js
+++ b/test/__node__/self-reference/code.js
@@ -1,0 +1,7 @@
+import { inject } from 'lib';
+
+@injectable()
+class Self {
+  @inject()
+  child: Self;
+}

--- a/test/__node__/self-reference/output.js
+++ b/test/__node__/self-reference/output.js
@@ -1,0 +1,23 @@
+"use strict";
+
+var _lib = require("lib");
+
+var _dec, _dec2, _dec3, _class, _class2, _descriptor, _temp;
+
+function _initializerDefineProperty(target, property, descriptor, context) { if (!descriptor) return; Object.defineProperty(target, property, { enumerable: descriptor.enumerable, configurable: descriptor.configurable, writable: descriptor.writable, value: descriptor.initializer ? descriptor.initializer.call(context) : void 0 }); }
+
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object.keys(descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object.defineProperty(target, property, desc); desc = null; } return desc; }
+
+function _initializerWarningHelper(descriptor, context) { throw new Error('Decorating class property failed. Please ensure that ' + 'proposal-class-properties is enabled and set to use loose mode. ' + 'To use proposal-class-properties in spec mode with decorators, wait for ' + 'the next major version of decorators in stage 2.'); }
+
+let Self = (_dec = injectable(), _dec2 = (0, _lib.inject)(), _dec3 = Reflect.metadata("design:type", Object), _dec(_class = (_class2 = (_temp = class Self {
+  constructor() {
+    _initializerDefineProperty(this, "child", _descriptor, this);
+  }
+
+}, _temp), (_descriptor = _applyDecoratedDescriptor(_class2.prototype, "child", [_dec2, _dec3], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: null
+})), _class2)) || _class);

--- a/test/serializeType.spec.ts
+++ b/test/serializeType.spec.ts
@@ -1,0 +1,43 @@
+import { isClassType, serializeType } from '../src/metadata/serializeType';
+import { types as t } from '@babel/core';
+import template from '@babel/template';
+
+const VoidZero = t.unaryExpression('void', t.numericLiteral(0));
+
+describe('serializeType', () => {
+  test('should return void for empty node', () => {
+    expect(serializeType(null as any, null)).toEqual(VoidZero);
+  });
+
+  test('should return void zero for untyped nodes', () => {
+    const node: t.FunctionExpression = template.expression
+      .ast`function (param) {}` as any;
+    console.log(node);
+    expect(serializeType(null as any, node.params[0])).toEqual(VoidZero);
+  });
+
+  test('should return void zero for unexepected nodes', () => {
+    const node = template.expression.ast`function (param) {}`;
+    expect(serializeType(null as any, node as any)).toEqual(VoidZero);
+  });
+
+  describe('isClassType', () => {
+    test('should recognize simple identifier', () => {
+      expect(isClassType('ClassName', t.identifier('ClassName'))).toBe(true);
+      expect(isClassType('ClassName', t.identifier('ClassN'))).toBe(false);
+    });
+
+    test('should recognize member expressions', () => {
+      expect(
+        isClassType('ClassName', template.expression.ast`ClassName.My.Type`)
+      ).toBe(true);
+      expect(
+        isClassType('ClassName', (template('ClassN.My')() as any).expression)
+      ).toBe(false);
+    });
+
+    test('should throw for wrong expressions', () => {
+      expect(() => isClassType('ClassName', t.stringLiteral('abc'))).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Due to babel transpilation nature, this would throw a ReferenceError.