### PR TITLE
feat: Add support for bigint type

### DIFF
--- a/src/metadata/serializeType.ts
+++ b/src/metadata/serializeType.ts
@@ -180,6 +180,9 @@ function serializeTypeNode(className: string, node: t.TSType): SerializedType {
     case 'TSNumberKeyword':
       return t.identifier('Number');
 
+    case 'TSBigIntKeyword':
+      return t.identifier('BigInt');
+
     case 'TSSymbolKeyword':
       return t.identifier('Symbol');
 


### PR DESCRIPTION
Adding a decorator to a property of type `bigint` would previously fail. This matches with TSC behavior.